### PR TITLE
Make GHA cache export non-fatal in release Docker builds

### DIFF
--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -88,7 +88,7 @@ jobs:
             BUILD_VERSION=${{ needs.release-tag.outputs.tag }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=docker-amd64
-          cache-to: type=gha,mode=max,scope=docker-amd64
+          cache-to: type=gha,mode=max,scope=docker-amd64,ignore-error=true
 
   # ---------------------------------------------------------------------------
   # Stage 2b: Build Docker image (arm64, native runner — no QEMU)
@@ -132,7 +132,7 @@ jobs:
             BUILD_VERSION=${{ needs.release-tag.outputs.tag }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=docker-arm64
-          cache-to: type=gha,mode=max,scope=docker-arm64
+          cache-to: type=gha,mode=max,scope=docker-arm64,ignore-error=true
 
   # ---------------------------------------------------------------------------
   # Stage 3: Merge digests into multi-arch manifest


### PR DESCRIPTION
## Summary

Every Release run since **July 6** has failed in both `Docker (amd64)` and `Docker (arm64)` with:

```
ERROR: failed to build: failed to solve: error writing layer blob: failed to reserve cache
```

The image build and push succeed — only the `cache-to: type=gha` export step fails, killing the job and skipping the manifest/release stages. Evidence it's a GitHub-side cache service issue, not our code:

- Last green release was July 4; the July 6 failure used the **same BuildKit version (v0.30.0)** as the green run.
- Identical error on every release since, across different PRs.
- Reruns fail identically, and purging all repo Actions caches (87 MB) didn't help.

## Fix

Add `ignore-error=true` to both `cache-to` lines, so a failed cache export logs a warning instead of aborting the release. `cache-from` still works, so cache hits resume automatically whenever GitHub's cache service recovers.

Merging this PR will itself trigger a Release run that exercises the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)